### PR TITLE
ALL: changed another file. to fileinfo.

### DIFF
--- a/Templates/ALL
+++ b/Templates/ALL
@@ -724,7 +724,7 @@
           "editable": true,
           "type": "terms",
           "loadingEditor": false,
-          "field": "file.magic.raw",
+          "field": "fileinfo.magic.raw",
           "exclude": [
             ""
           ],


### PR DESCRIPTION
I found another file that had to be changed to fileinfo in the ALL dashboard.
