### PR TITLE
change country_code2 to region_name on USA maps so that states get highlighted properly.

### DIFF
--- a/Templates/ALERTS
+++ b/Templates/ALERTS
@@ -211,7 +211,7 @@
           "spyable": true,
           "index_limit": 0,
           "title": "USA",
-          "field": "geoip.country_code2"
+          "field": "geoip.region_name"
         },
         {
           "span": 5,

--- a/Templates/ALL
+++ b/Templates/ALL
@@ -582,7 +582,7 @@
             ]
           },
           "title": "USA",
-          "field": "geoip.country_code2"
+          "field": "geoip.region_name"
         },
         {
           "error": false,

--- a/Templates/DNS
+++ b/Templates/DNS
@@ -211,7 +211,7 @@
           "spyable": true,
           "index_limit": 0,
           "title": "USA",
-          "field": "geoip.country_code2"
+          "field": "geoip.region_name"
         },
         {
           "span": 5,

--- a/Templates/FILE-Transactions
+++ b/Templates/FILE-Transactions
@@ -256,7 +256,7 @@
           "spyable": true,
           "index_limit": 0,
           "title": "USA",
-          "field": "geoip.country_code2"
+          "field": "geoip.region_name"
         },
         {
           "span": 5,

--- a/Templates/HTTP
+++ b/Templates/HTTP
@@ -211,7 +211,7 @@
           "spyable": true,
           "index_limit": 0,
           "title": "USA",
-          "field": "geoip.country_code2"
+          "field": "geoip.region_name"
         },
         {
           "span": 5,

--- a/Templates/HTTP-Extended-Custom
+++ b/Templates/HTTP-Extended-Custom
@@ -699,7 +699,7 @@
               0
             ]
           },
-          "field": "geoip.country_code2",
+          "field": "geoip.region_name",
           "title": "HTTP USA Map"
         }
       ],

--- a/Templates/PRIVACY
+++ b/Templates/PRIVACY
@@ -882,7 +882,7 @@
               0
             ]
           },
-          "field": "geoip.country_code2",
+          "field": "geoip.region_name",
           "title": "HTTP USA Map"
         }
       ],

--- a/Templates/SSH
+++ b/Templates/SSH
@@ -211,7 +211,7 @@
           "spyable": true,
           "index_limit": 0,
           "title": "USA",
-          "field": "geoip.country_code2"
+          "field": "geoip.region_name"
         },
         {
           "span": 5,

--- a/Templates/TLS
+++ b/Templates/TLS
@@ -211,7 +211,7 @@
           "spyable": true,
           "index_limit": 0,
           "title": "USA",
-          "field": "geoip.country_code2"
+          "field": "geoip.region_name"
         },
         {
           "span": 5,


### PR DESCRIPTION
These change the geoip field used to dispaly USA maps from coutry_code2 to region_name so that
US states are hightlighted properly in USA maps.
